### PR TITLE
fix: invalid values for error count metrics

### DIFF
--- a/src/middleware/api-metrics.middleware.ts
+++ b/src/middleware/api-metrics.middleware.ts
@@ -132,12 +132,10 @@ export class ApiMetricsMiddleware implements NestMiddleware {
           this.httpServerResponseSuccessCount.add(1);
           break;
         case 'client_error':
-          this.httpServerResponseErrorCount.add(1);
           this.httpClientRequestErrorCount.add(1);
           break;
         case 'server_error':
           this.httpServerResponseErrorCount.add(1);
-          this.httpClientRequestErrorCount.add(1);
           break;
       }
 

--- a/tests/e2e/middleware/api-metrics.middleware.spec.ts
+++ b/tests/e2e/middleware/api-metrics.middleware.spec.ts
@@ -255,10 +255,12 @@ describe('Api Metrics Middleware', () => {
       }).compile();
 
       app = testingModule.createNestApplication();
+      app.useLogger(false);
+
       await app.init();
 
       const agent = request(app.getHttpServer());
-      await agent.get('/example/4/invalid-route?foo=bar');
+      await agent.get('/example/internal-error');
 
       // Workaround for delay of metrics going to prometheus
       await new Promise(resolve => setTimeout(resolve, 200));
@@ -286,11 +288,13 @@ describe('Api Metrics Middleware', () => {
       }).compile();
 
       app = testingModule.createNestApplication<NestFastifyApplication>(new FastifyAdapter());
+      app.useLogger(false);
+
       await app.init();
       await app.getHttpAdapter().getInstance().ready();
 
       const agent = request(app.getHttpServer());
-      await agent.get('/example/4/invalid-route?foo=bar');
+      await agent.get('/example/internal-error');
 
       // Workaround for delay of metrics going to prometheus
       await new Promise(resolve => setTimeout(resolve, 200));


### PR DESCRIPTION
`http.client.request.error.count` and `http.server.response.error.count`
returned the same values instead of counting 4xx status code for the
former and 5xx status codes for the later

Fixes pragmaticivan/nestjs-otel#425